### PR TITLE
build(deps): bump fast-xml-parser and @aws-sdk/credential-providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,23 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
@@ -142,12 +159,12 @@
       "optional": true
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.306.0.tgz",
-      "integrity": "sha512-ewCvdUrMJMlnkNaqXdG7L2H6O7CDI036y6lkTU8gQqa2lCzZvqBkzz6R5NbWqb8TJPi69Z7lXEITgk2b0+pl6w==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
+      "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -155,45 +172,46 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.306.0.tgz",
-      "integrity": "sha512-jYDs8yjEU0cyb/nZj2C6nz300lR8dOq+SqsxgdqgW9R46AGL6J4pPAY3/PRFHyC3LsRP3y/qC5w5UD/8Q0UuWg==",
+      "version": "3.362.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.362.0.tgz",
+      "integrity": "sha512-Rgl5yZOa1B5/UB8+Brlwixv8vzn+4GxoA0jLo8iG5I7k6KgzwZix/EgllKLdS5MLht6JFHDxFIhaI/6KkTD/5A==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.306.0",
-        "@aws-sdk/config-resolver": "3.306.0",
-        "@aws-sdk/credential-provider-node": "3.306.0",
-        "@aws-sdk/fetch-http-handler": "3.306.0",
-        "@aws-sdk/hash-node": "3.306.0",
-        "@aws-sdk/invalid-dependency": "3.306.0",
-        "@aws-sdk/middleware-content-length": "3.306.0",
-        "@aws-sdk/middleware-endpoint": "3.306.0",
-        "@aws-sdk/middleware-host-header": "3.306.0",
-        "@aws-sdk/middleware-logger": "3.306.0",
-        "@aws-sdk/middleware-recursion-detection": "3.306.0",
-        "@aws-sdk/middleware-retry": "3.306.0",
-        "@aws-sdk/middleware-serde": "3.306.0",
-        "@aws-sdk/middleware-signing": "3.306.0",
-        "@aws-sdk/middleware-stack": "3.306.0",
-        "@aws-sdk/middleware-user-agent": "3.306.0",
-        "@aws-sdk/node-config-provider": "3.306.0",
-        "@aws-sdk/node-http-handler": "3.306.0",
-        "@aws-sdk/protocol-http": "3.306.0",
-        "@aws-sdk/smithy-client": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
-        "@aws-sdk/url-parser": "3.306.0",
-        "@aws-sdk/util-base64": "3.303.0",
-        "@aws-sdk/util-body-length-browser": "3.303.0",
-        "@aws-sdk/util-body-length-node": "3.303.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.306.0",
-        "@aws-sdk/util-defaults-mode-node": "3.306.0",
-        "@aws-sdk/util-endpoints": "3.306.0",
-        "@aws-sdk/util-retry": "3.306.0",
-        "@aws-sdk/util-user-agent-browser": "3.306.0",
-        "@aws-sdk/util-user-agent-node": "3.306.0",
-        "@aws-sdk/util-utf8": "3.303.0",
+        "@aws-sdk/client-sts": "3.362.0",
+        "@aws-sdk/config-resolver": "3.357.0",
+        "@aws-sdk/credential-provider-node": "3.362.0",
+        "@aws-sdk/fetch-http-handler": "3.357.0",
+        "@aws-sdk/hash-node": "3.357.0",
+        "@aws-sdk/invalid-dependency": "3.357.0",
+        "@aws-sdk/middleware-content-length": "3.357.0",
+        "@aws-sdk/middleware-endpoint": "3.357.0",
+        "@aws-sdk/middleware-host-header": "3.357.0",
+        "@aws-sdk/middleware-logger": "3.357.0",
+        "@aws-sdk/middleware-recursion-detection": "3.357.0",
+        "@aws-sdk/middleware-retry": "3.362.0",
+        "@aws-sdk/middleware-serde": "3.357.0",
+        "@aws-sdk/middleware-signing": "3.357.0",
+        "@aws-sdk/middleware-stack": "3.357.0",
+        "@aws-sdk/middleware-user-agent": "3.357.0",
+        "@aws-sdk/node-config-provider": "3.357.0",
+        "@aws-sdk/node-http-handler": "3.360.0",
+        "@aws-sdk/smithy-client": "3.360.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/url-parser": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.360.0",
+        "@aws-sdk/util-defaults-mode-node": "3.360.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-retry": "3.362.0",
+        "@aws-sdk/util-user-agent-browser": "3.357.0",
+        "@aws-sdk/util-user-agent-node": "3.357.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -201,42 +219,43 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.306.0.tgz",
-      "integrity": "sha512-uqfLUOP9LlBoqXe3P250TPX3fGrabfRt9Q9rlLFK0fVBI7HPIQ/wsPplLoPrMeT04qQmTI03UnVKMNza3GqyIg==",
+      "version": "3.362.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.362.0.tgz",
+      "integrity": "sha512-11M+S7mlr8MBE8NB2yPZWOeb7BV4pcfQ+2p9EE9jVDbcq7VW21chvnf4F+L11aNV1yNtswsnHOSHLKM6YBMM7w==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.306.0",
-        "@aws-sdk/fetch-http-handler": "3.306.0",
-        "@aws-sdk/hash-node": "3.306.0",
-        "@aws-sdk/invalid-dependency": "3.306.0",
-        "@aws-sdk/middleware-content-length": "3.306.0",
-        "@aws-sdk/middleware-endpoint": "3.306.0",
-        "@aws-sdk/middleware-host-header": "3.306.0",
-        "@aws-sdk/middleware-logger": "3.306.0",
-        "@aws-sdk/middleware-recursion-detection": "3.306.0",
-        "@aws-sdk/middleware-retry": "3.306.0",
-        "@aws-sdk/middleware-serde": "3.306.0",
-        "@aws-sdk/middleware-stack": "3.306.0",
-        "@aws-sdk/middleware-user-agent": "3.306.0",
-        "@aws-sdk/node-config-provider": "3.306.0",
-        "@aws-sdk/node-http-handler": "3.306.0",
-        "@aws-sdk/protocol-http": "3.306.0",
-        "@aws-sdk/smithy-client": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
-        "@aws-sdk/url-parser": "3.306.0",
-        "@aws-sdk/util-base64": "3.303.0",
-        "@aws-sdk/util-body-length-browser": "3.303.0",
-        "@aws-sdk/util-body-length-node": "3.303.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.306.0",
-        "@aws-sdk/util-defaults-mode-node": "3.306.0",
-        "@aws-sdk/util-endpoints": "3.306.0",
-        "@aws-sdk/util-retry": "3.306.0",
-        "@aws-sdk/util-user-agent-browser": "3.306.0",
-        "@aws-sdk/util-user-agent-node": "3.306.0",
-        "@aws-sdk/util-utf8": "3.303.0",
+        "@aws-sdk/config-resolver": "3.357.0",
+        "@aws-sdk/fetch-http-handler": "3.357.0",
+        "@aws-sdk/hash-node": "3.357.0",
+        "@aws-sdk/invalid-dependency": "3.357.0",
+        "@aws-sdk/middleware-content-length": "3.357.0",
+        "@aws-sdk/middleware-endpoint": "3.357.0",
+        "@aws-sdk/middleware-host-header": "3.357.0",
+        "@aws-sdk/middleware-logger": "3.357.0",
+        "@aws-sdk/middleware-recursion-detection": "3.357.0",
+        "@aws-sdk/middleware-retry": "3.362.0",
+        "@aws-sdk/middleware-serde": "3.357.0",
+        "@aws-sdk/middleware-stack": "3.357.0",
+        "@aws-sdk/middleware-user-agent": "3.357.0",
+        "@aws-sdk/node-config-provider": "3.357.0",
+        "@aws-sdk/node-http-handler": "3.360.0",
+        "@aws-sdk/smithy-client": "3.360.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/url-parser": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.360.0",
+        "@aws-sdk/util-defaults-mode-node": "3.360.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-retry": "3.362.0",
+        "@aws-sdk/util-user-agent-browser": "3.357.0",
+        "@aws-sdk/util-user-agent-node": "3.357.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -244,42 +263,43 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.306.0.tgz",
-      "integrity": "sha512-O27yrApCkbC0/uPRb1aHkENpFSqrkPbXRi76NF/8T97qC8bngRpy6yeafcQRrp9NGQSF/m9xbPWYsQuiurqedw==",
+      "version": "3.362.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.362.0.tgz",
+      "integrity": "sha512-/urfavz0BjyeWSahp6oh9DjzV8oM5EPmza7iIZXJaPyK03enjse9A52vse4/EfKWaSHtapIgV3ZUKvYDk8AcKA==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.306.0",
-        "@aws-sdk/fetch-http-handler": "3.306.0",
-        "@aws-sdk/hash-node": "3.306.0",
-        "@aws-sdk/invalid-dependency": "3.306.0",
-        "@aws-sdk/middleware-content-length": "3.306.0",
-        "@aws-sdk/middleware-endpoint": "3.306.0",
-        "@aws-sdk/middleware-host-header": "3.306.0",
-        "@aws-sdk/middleware-logger": "3.306.0",
-        "@aws-sdk/middleware-recursion-detection": "3.306.0",
-        "@aws-sdk/middleware-retry": "3.306.0",
-        "@aws-sdk/middleware-serde": "3.306.0",
-        "@aws-sdk/middleware-stack": "3.306.0",
-        "@aws-sdk/middleware-user-agent": "3.306.0",
-        "@aws-sdk/node-config-provider": "3.306.0",
-        "@aws-sdk/node-http-handler": "3.306.0",
-        "@aws-sdk/protocol-http": "3.306.0",
-        "@aws-sdk/smithy-client": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
-        "@aws-sdk/url-parser": "3.306.0",
-        "@aws-sdk/util-base64": "3.303.0",
-        "@aws-sdk/util-body-length-browser": "3.303.0",
-        "@aws-sdk/util-body-length-node": "3.303.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.306.0",
-        "@aws-sdk/util-defaults-mode-node": "3.306.0",
-        "@aws-sdk/util-endpoints": "3.306.0",
-        "@aws-sdk/util-retry": "3.306.0",
-        "@aws-sdk/util-user-agent-browser": "3.306.0",
-        "@aws-sdk/util-user-agent-node": "3.306.0",
-        "@aws-sdk/util-utf8": "3.303.0",
+        "@aws-sdk/config-resolver": "3.357.0",
+        "@aws-sdk/fetch-http-handler": "3.357.0",
+        "@aws-sdk/hash-node": "3.357.0",
+        "@aws-sdk/invalid-dependency": "3.357.0",
+        "@aws-sdk/middleware-content-length": "3.357.0",
+        "@aws-sdk/middleware-endpoint": "3.357.0",
+        "@aws-sdk/middleware-host-header": "3.357.0",
+        "@aws-sdk/middleware-logger": "3.357.0",
+        "@aws-sdk/middleware-recursion-detection": "3.357.0",
+        "@aws-sdk/middleware-retry": "3.362.0",
+        "@aws-sdk/middleware-serde": "3.357.0",
+        "@aws-sdk/middleware-stack": "3.357.0",
+        "@aws-sdk/middleware-user-agent": "3.357.0",
+        "@aws-sdk/node-config-provider": "3.357.0",
+        "@aws-sdk/node-http-handler": "3.360.0",
+        "@aws-sdk/smithy-client": "3.360.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/url-parser": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.360.0",
+        "@aws-sdk/util-defaults-mode-node": "3.360.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-retry": "3.362.0",
+        "@aws-sdk/util-user-agent-browser": "3.357.0",
+        "@aws-sdk/util-user-agent-node": "3.357.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -287,46 +307,47 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.306.0.tgz",
-      "integrity": "sha512-LivDrH0OnAZDC3EB6hVrrl25itlMLn/C/epwDjpnH2Qdq+gjbZ0ElVNu8XOX4qaXoo0zyV5pztnzwD/A76mX2g==",
+      "version": "3.362.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.362.0.tgz",
+      "integrity": "sha512-4Kh6oM2hfJbckuMb9O5eRIG66s/eA0wazXYvCbxSiSi3XgkX9L4m5OSNxlzLPe7uVgkEx8ykuk8Xz6qZrZWJcQ==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.306.0",
-        "@aws-sdk/credential-provider-node": "3.306.0",
-        "@aws-sdk/fetch-http-handler": "3.306.0",
-        "@aws-sdk/hash-node": "3.306.0",
-        "@aws-sdk/invalid-dependency": "3.306.0",
-        "@aws-sdk/middleware-content-length": "3.306.0",
-        "@aws-sdk/middleware-endpoint": "3.306.0",
-        "@aws-sdk/middleware-host-header": "3.306.0",
-        "@aws-sdk/middleware-logger": "3.306.0",
-        "@aws-sdk/middleware-recursion-detection": "3.306.0",
-        "@aws-sdk/middleware-retry": "3.306.0",
-        "@aws-sdk/middleware-sdk-sts": "3.306.0",
-        "@aws-sdk/middleware-serde": "3.306.0",
-        "@aws-sdk/middleware-signing": "3.306.0",
-        "@aws-sdk/middleware-stack": "3.306.0",
-        "@aws-sdk/middleware-user-agent": "3.306.0",
-        "@aws-sdk/node-config-provider": "3.306.0",
-        "@aws-sdk/node-http-handler": "3.306.0",
-        "@aws-sdk/protocol-http": "3.306.0",
-        "@aws-sdk/smithy-client": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
-        "@aws-sdk/url-parser": "3.306.0",
-        "@aws-sdk/util-base64": "3.303.0",
-        "@aws-sdk/util-body-length-browser": "3.303.0",
-        "@aws-sdk/util-body-length-node": "3.303.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.306.0",
-        "@aws-sdk/util-defaults-mode-node": "3.306.0",
-        "@aws-sdk/util-endpoints": "3.306.0",
-        "@aws-sdk/util-retry": "3.306.0",
-        "@aws-sdk/util-user-agent-browser": "3.306.0",
-        "@aws-sdk/util-user-agent-node": "3.306.0",
-        "@aws-sdk/util-utf8": "3.303.0",
-        "fast-xml-parser": "4.1.2",
+        "@aws-sdk/config-resolver": "3.357.0",
+        "@aws-sdk/credential-provider-node": "3.362.0",
+        "@aws-sdk/fetch-http-handler": "3.357.0",
+        "@aws-sdk/hash-node": "3.357.0",
+        "@aws-sdk/invalid-dependency": "3.357.0",
+        "@aws-sdk/middleware-content-length": "3.357.0",
+        "@aws-sdk/middleware-endpoint": "3.357.0",
+        "@aws-sdk/middleware-host-header": "3.357.0",
+        "@aws-sdk/middleware-logger": "3.357.0",
+        "@aws-sdk/middleware-recursion-detection": "3.357.0",
+        "@aws-sdk/middleware-retry": "3.362.0",
+        "@aws-sdk/middleware-sdk-sts": "3.357.0",
+        "@aws-sdk/middleware-serde": "3.357.0",
+        "@aws-sdk/middleware-signing": "3.357.0",
+        "@aws-sdk/middleware-stack": "3.357.0",
+        "@aws-sdk/middleware-user-agent": "3.357.0",
+        "@aws-sdk/node-config-provider": "3.357.0",
+        "@aws-sdk/node-http-handler": "3.360.0",
+        "@aws-sdk/smithy-client": "3.360.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/url-parser": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.360.0",
+        "@aws-sdk/util-defaults-mode-node": "3.360.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-retry": "3.362.0",
+        "@aws-sdk/util-user-agent-browser": "3.357.0",
+        "@aws-sdk/util-user-agent-node": "3.357.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -334,14 +355,14 @@
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.306.0.tgz",
-      "integrity": "sha512-kpqHu6LvNMYxullm+tLCsY6KQ2mZUxZTdyWJKTYLZCTxj4HcGJxf4Jxj9dwFAZVl/clcVPGWcHJaQJjyjwzBzw==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.357.0.tgz",
+      "integrity": "sha512-cukfg0nX7Tzx/xFyH5F4Eyb8DA1ITCGtSQv4vnEjgUop+bkzckuGLKEeBcBhyZY+aw+2C9CVwIHwIMhRm0ul5w==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.306.0",
-        "@aws-sdk/util-config-provider": "3.295.0",
-        "@aws-sdk/util-middleware": "3.306.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -349,14 +370,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.306.0.tgz",
-      "integrity": "sha512-fjmTDTscMztA28YcmsFfrW95/yJ3Qn9kcNHsSv3iKHXb5qHAZRDANBKmymitpV3cRfkXhOhpgPqCoByjNi3I6w==",
+      "version": "3.362.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.362.0.tgz",
+      "integrity": "sha512-VkNlk0EGWsy9RhYeK9EqC6jcLplSyoKR5faWtDoxA1P9+ESWClrxkFpsxDZEGLPR0C7MVb2cO5qn/uvceb17Vw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.306.0",
-        "@aws-sdk/property-provider": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/client-cognito-identity": "3.362.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -364,13 +385,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.306.0.tgz",
-      "integrity": "sha512-DTH+aMvMu+LAoWW+yfPkWzFXt/CPNFQ7+/4xiMnc7FWf+tjt+HZIrPECAV2rBVppNCkh7PC+xDSN61PFvBYOsw==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.357.0.tgz",
+      "integrity": "sha512-UOecwfqvXgJVqhfWSZ2S44v2Nq2oceW0PQVQp0JAa9opc2rxSVIfyOhPr0yMoPmpyNcP22rgeg6ce70KULYwiA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -378,15 +399,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.306.0.tgz",
-      "integrity": "sha512-WdrNhq2MwvjZk2I8Of+bZ/qWHG2hREQpwlBiG3tMeEkuywx7M1x3Rt0eHgiR1sTcm05kxNn0rB4OeWOeek37cA==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.357.0.tgz",
+      "integrity": "sha512-upw/bfsl7/WydT6gM0lBuR4Ipp4fzYm/E3ObFr0Mg5OkgVPt5ZJE+eeFTvwCpDdBSTKs4JfrK6/iEK8A23Q1jQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.306.0",
-        "@aws-sdk/property-provider": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
-        "@aws-sdk/url-parser": "3.306.0",
+        "@aws-sdk/node-config-provider": "3.357.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/url-parser": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -394,19 +415,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.306.0.tgz",
-      "integrity": "sha512-6VvP0YmXVd+pCnlD2iTDhNvO2Ikzyk9Ade/t5R1eZ4Vf1gKhDiNA2/AgDt9XlzQHk7iw1okTmYCeQsK1j+7+NQ==",
+      "version": "3.362.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.362.0.tgz",
+      "integrity": "sha512-56gOo0XrqfEXTYrpWwZEYqrKEyNNpyNNvagfuP29d4aqok7ON5CkL1ymmKhNuDGHbbHXVGOIGdLNJBkGBgwE1g==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.306.0",
-        "@aws-sdk/credential-provider-imds": "3.306.0",
-        "@aws-sdk/credential-provider-process": "3.306.0",
-        "@aws-sdk/credential-provider-sso": "3.306.0",
-        "@aws-sdk/credential-provider-web-identity": "3.306.0",
-        "@aws-sdk/property-provider": "3.306.0",
-        "@aws-sdk/shared-ini-file-loader": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/credential-provider-env": "3.357.0",
+        "@aws-sdk/credential-provider-imds": "3.357.0",
+        "@aws-sdk/credential-provider-process": "3.357.0",
+        "@aws-sdk/credential-provider-sso": "3.362.0",
+        "@aws-sdk/credential-provider-web-identity": "3.357.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -414,20 +435,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.306.0.tgz",
-      "integrity": "sha512-HYuMmABRzbVWo03CElRUa+T+yenyUmLkwNCVAAvIRmbr9TnLT/bJbplXpUSzgSCS6T3TgwbQ9zf9xY9tX+gHzA==",
+      "version": "3.362.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.362.0.tgz",
+      "integrity": "sha512-G/oCGTdN3Gx1HgSX6KlGC71q9EQw9luSgGGIgZHAw9u3IllLEARqxVQ5PUPlhEM4FkNNMpzicUbWeI5NeMRuyA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.306.0",
-        "@aws-sdk/credential-provider-imds": "3.306.0",
-        "@aws-sdk/credential-provider-ini": "3.306.0",
-        "@aws-sdk/credential-provider-process": "3.306.0",
-        "@aws-sdk/credential-provider-sso": "3.306.0",
-        "@aws-sdk/credential-provider-web-identity": "3.306.0",
-        "@aws-sdk/property-provider": "3.306.0",
-        "@aws-sdk/shared-ini-file-loader": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/credential-provider-env": "3.357.0",
+        "@aws-sdk/credential-provider-imds": "3.357.0",
+        "@aws-sdk/credential-provider-ini": "3.362.0",
+        "@aws-sdk/credential-provider-process": "3.357.0",
+        "@aws-sdk/credential-provider-sso": "3.362.0",
+        "@aws-sdk/credential-provider-web-identity": "3.357.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -435,14 +456,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.306.0.tgz",
-      "integrity": "sha512-2RezGskHqJeHtGbK7CqhGNAoqXgQJb7FfPFqwUQ9oVDZS8f145jVwajjHcc7Qn3IwGoqylMF3uXIljUv89uDzA==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.357.0.tgz",
+      "integrity": "sha512-qFWWilFPsc2hR7O0KIhwcE78w+pVIK+uQR6MQMfdRyxUndgiuCorJwVjedc3yZtmnoELHF34j+m8whTBXv9E7Q==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.306.0",
-        "@aws-sdk/shared-ini-file-loader": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -450,16 +471,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.306.0.tgz",
-      "integrity": "sha512-6msBUisMdOzk0ywJQNunZIb0rVMaA6GTx7ek8aCuWInX+lJm0oEPPVp+b3ewwVheih1rRC2bgNk8eAjfC9YcKw==",
+      "version": "3.362.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.362.0.tgz",
+      "integrity": "sha512-jf5jG8IQXNSTuOPMT0SMOpBi+Tlct+3Ik5njpEECFzo5POzU8DgJkc2ALMNW5j+XojuchwgeqWZclPRoacKjVw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.306.0",
-        "@aws-sdk/property-provider": "3.306.0",
-        "@aws-sdk/shared-ini-file-loader": "3.306.0",
-        "@aws-sdk/token-providers": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/client-sso": "3.362.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+        "@aws-sdk/token-providers": "3.362.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -467,13 +488,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.306.0.tgz",
-      "integrity": "sha512-MOQGQaOtdo4zLQZ1bRjD2n1PUzfNty+sKe+1wlm5bIqTN93UX3S8f0QznucZr7uJxI4Z14ZLwuYeAUV4Tgchlw==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.357.0.tgz",
+      "integrity": "sha512-0KRRAFrXy5HJe2vqnCWCoCS+fQw7IoIj3KQsuURJMW4F+ifisxCgEsh3brJ2LQlN4ElWTRJhlrDHNZ/pd61D4w==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -481,52 +502,64 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.306.0.tgz",
-      "integrity": "sha512-QKICU6m3onOSuANJfElKFSAZYI4CqJY9X4gtsebPN8ueroT1LEMgd2GdGodyLgbVa2sxze39IfKNC5+gASk3Bg==",
+      "version": "3.362.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.362.0.tgz",
+      "integrity": "sha512-1phrbs74ktU5P4hwByemSPDwv9aM8m1MLOgXFBdQ1DgFTE/Y/50nqsUQMP45idk+/E/rRgUR6PGwZDb+8tWQpw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.306.0",
-        "@aws-sdk/client-sso": "3.306.0",
-        "@aws-sdk/client-sts": "3.306.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.306.0",
-        "@aws-sdk/credential-provider-env": "3.306.0",
-        "@aws-sdk/credential-provider-imds": "3.306.0",
-        "@aws-sdk/credential-provider-ini": "3.306.0",
-        "@aws-sdk/credential-provider-node": "3.306.0",
-        "@aws-sdk/credential-provider-process": "3.306.0",
-        "@aws-sdk/credential-provider-sso": "3.306.0",
-        "@aws-sdk/credential-provider-web-identity": "3.306.0",
-        "@aws-sdk/property-provider": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/client-cognito-identity": "3.362.0",
+        "@aws-sdk/client-sso": "3.362.0",
+        "@aws-sdk/client-sts": "3.362.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.362.0",
+        "@aws-sdk/credential-provider-env": "3.357.0",
+        "@aws-sdk/credential-provider-imds": "3.357.0",
+        "@aws-sdk/credential-provider-ini": "3.362.0",
+        "@aws-sdk/credential-provider-node": "3.362.0",
+        "@aws-sdk/credential-provider-process": "3.357.0",
+        "@aws-sdk/credential-provider-sso": "3.362.0",
+        "@aws-sdk/credential-provider-web-identity": "3.357.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.306.0.tgz",
-      "integrity": "sha512-T8OODOnPpDqkXS+XSMIkd6hf90h833JLN93wq3ibbyD/WvGveufFFHsbsNyccE9+CSv/BjEuN5QbHqTKTp3BlA==",
+    "node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.357.0.tgz",
+      "integrity": "sha512-bqenTHG6GH6aCk/Il+ooWXVVAZuc8lOgVEy9bE2hI49oVqT8zSuXxQB+w1WWyZoAOPcelsjayB1wfPub8VDBxQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.306.0",
-        "@aws-sdk/querystring-builder": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
-        "@aws-sdk/util-base64": "3.303.0",
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.357.0.tgz",
+      "integrity": "sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/querystring-builder": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.306.0.tgz",
-      "integrity": "sha512-EcSLd6gKoDEEBPZqEv+Ky9gIyefwyyrAJGILGKoYBmcOIY7Y0xKId0hxCa9/1xvWTaVC1u+rA06DGgksZOa78w==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.357.0.tgz",
+      "integrity": "sha512-fq3LS9AxHKb7dTZkm6iM1TrGk6XOTZz96iEZPME1+vjiSEXGWuebHt87q92n+KozVGRypn9MId3lHOPBBjygNQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.306.0",
-        "@aws-sdk/util-buffer-from": "3.303.0",
-        "@aws-sdk/util-utf8": "3.303.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -534,19 +567,19 @@
       }
     },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.306.0.tgz",
-      "integrity": "sha512-9Mkcr+qG7QR4R5bJcA8bBNd8E2x6WaZStsQ3QeFbdQr3V3Tunvra/KlCFsEL55GgU8BZt5isOaHqq7uxs5ILtQ==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.357.0.tgz",
+      "integrity": "sha512-HnCYZczf0VdyxMVMMxmA3QJAyyPSFbcMtZzgKbxVTWTG7GKpQe0psWZu/7O2Nk31mKg6vEUdiP1FylqLBsgMOA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.303.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.303.0.tgz",
-      "integrity": "sha512-IitBTr+pou7v5BrYLFH/SbIf3g1LIgMhcI3bDXBq2FjzmDftj4bW8BOmg05b9YKf2TrrggvJ4yk/jH+yYFXoJQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -556,13 +589,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.306.0.tgz",
-      "integrity": "sha512-JbONf2Ms+/DVRcpFNsKGdOQU94Js56KV+AhlPJmCwLxfyWvQjTt0KxFC1Dd+cjeNEXUduvBarrehgsqFlWnoHQ==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.357.0.tgz",
+      "integrity": "sha512-zQOFEyzOXAgN4M54tYNWGxKxnyzY0WwYDTFzh9riJRmxN1hTEKHUKmze4nILIf5rkQmOG4kTf1qmfazjkvZAhw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -570,15 +603,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.306.0.tgz",
-      "integrity": "sha512-i3QRiwgkcsuVN55O7l8I/QGwCypGRZXdYkPjU56LI2w2oiZ82f/nVMNXVc+ZFm2YH7WbCE+5jguw2J7HXdOlyQ==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.357.0.tgz",
+      "integrity": "sha512-ScJi0SL8X/Lyi0Fp5blg0QN/Z6PoRwV/ZJXd8dQkXSznkbSvJHfqPP0xk/w3GcQ1TKsu5YEPfeYy8ejcq+7Pgg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/middleware-serde": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
-        "@aws-sdk/url-parser": "3.306.0",
-        "@aws-sdk/util-middleware": "3.306.0",
+        "@aws-sdk/middleware-serde": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/url-parser": "3.357.0",
+        "@aws-sdk/util-middleware": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -586,13 +619,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.306.0.tgz",
-      "integrity": "sha512-mHDHK9E+c7HwMlrCJ+VFSB6tkq8oJVkYEHCvPkdrnzN/g9P/d/UhPIeGapZXMbAIZEaLpEGqs536mYzeRKZG8A==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.357.0.tgz",
+      "integrity": "sha512-HuGLcP7JP1qJ5wGT9GSlEknDaTSnOzHY4T6IPFuvFjAy3PvY5siQNm6+VRqdVS+n6/kzpL3JP5sAVM3aoxHT6Q==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -600,12 +633,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.306.0.tgz",
-      "integrity": "sha512-1FRHp/QB0Lb+CgP+c9CYW6BZh+q+5pnuOKo/Rd6hjYiM+kT1G/cWdXnMJQBR4rbTCTixbqCnObNJ1EyP/ofQhQ==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.357.0.tgz",
+      "integrity": "sha512-dncT3tr+lZ9+duZo52rASgO6AKVwRcsc2/T93gmaYVrJqI6WWAwQ7yML5s72l9ZjQ5LZ+4jjrgtlufavAS0eCg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -613,13 +646,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.306.0.tgz",
-      "integrity": "sha512-Hpj42ZLmwCy/CtVxi57NTeOEPoUJlivF3VIgowZ9JhaF61cakVKyrJ+f3jwXciDUtuYrdKm5Wf6prW6apWo0YA==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.357.0.tgz",
+      "integrity": "sha512-AXC54IeDS3jC1dbbkYHML4STvBPcKZ4IJTWdjEK1RCOgqXd0Ze1cE1e21wyj1tM6prF03zLyvpBd+3TS++nqfA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -627,16 +660,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.306.0.tgz",
-      "integrity": "sha512-eMyfr/aeurXXDz4x+WVrvLI8fVDP6klJOjziBEWZ/MUNP/hTFhkiQsMVbvT6O4Pspp7+FgCSdcUPG6Os2gK+CQ==",
+      "version": "3.362.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.362.0.tgz",
+      "integrity": "sha512-ZFsty5fXIdvTTm+GnTtCPre89b2QFZYQmD0L5nhJULDFoU5Fz/bsI5C3b98/wb4YCAIfXBZpx4Kh2RAEKnxkyg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.306.0",
-        "@aws-sdk/service-error-classification": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
-        "@aws-sdk/util-middleware": "3.306.0",
-        "@aws-sdk/util-retry": "3.306.0",
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/service-error-classification": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-middleware": "3.357.0",
+        "@aws-sdk/util-retry": "3.362.0",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -645,13 +678,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.306.0.tgz",
-      "integrity": "sha512-2rSAR3nc5faYuEnh1KxQMCMCkEkJyaDfA3zwWLqZ+/TBCH0PlPkBv+Z9yXmteEki0vI5Hr+e+atTutJZoyG13g==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.357.0.tgz",
+      "integrity": "sha512-Ng2VjLrPiL02QOcs1qs9jG2boO4Gn+v3VIbOJLG4zXcfbSq55iIWtlmr2ljfw9vP5aLhWtcODfmKHS5Bp+019Q==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/middleware-signing": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -659,12 +692,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.306.0.tgz",
-      "integrity": "sha512-M3gyPLPduZXMvdgt4XEpVO+3t0ZVPdgeQQwG6JnXv0dgyUizshYs4lrVOAb1KwF6StsmkrAgSN+I273elLiKjA==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.357.0.tgz",
+      "integrity": "sha512-bGI4kYuuEsFjlANbyJLyy4AovETnyf/SukgLOG7Qjbua+ZGuzvRhMsk21mBKKGrnsTO4PmtieJo6xClThGAN8g==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -672,16 +705,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.306.0.tgz",
-      "integrity": "sha512-JhpSriN4xa4a/p5gAPL0OWFKJF4eWYU3K+LLlXBNGMbxg/qNL4skgT4dMFe3ii9EW8kI+r6tpvSgC+lP7/Tyng==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.357.0.tgz",
+      "integrity": "sha512-yB9ewEqI6Fw1OrmKFrUypbCqN5ijk06UGPochybamMuPxxkwMT3bnrm7eezsCA+TZbJyKhpffpyobwuv+xGNrA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.306.0",
-        "@aws-sdk/protocol-http": "3.306.0",
-        "@aws-sdk/signature-v4": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
-        "@aws-sdk/util-middleware": "3.306.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/signature-v4": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-middleware": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -689,9 +722,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.306.0.tgz",
-      "integrity": "sha512-G//a6MVSxyFVpOMZ+dzT3+w7XblOd2tRJ5g+/okjn3pNBLbo5o9Hu33K/bz0SQjT/m5mU2F9m0wcdCPYbRPysg==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.357.0.tgz",
+      "integrity": "sha512-nNV+jfwGwmbOGZujAY/U8AW3EbVlxa9DJDLz3TPp/39o6Vu5KEzHJyDDNreo2k9V/TMvV+nOzHafufgPdagv7w==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -701,14 +734,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.306.0.tgz",
-      "integrity": "sha512-tP6I+Lbs68muPfdMA6Rfc+8fYo49nEn9A3RMiOU2COClWsmiZatpbK9UYlqIOxeGB/s2jI7hXmQq6tT2LStLSg==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.357.0.tgz",
+      "integrity": "sha512-M/CsAXjGblZS4rEbMb0Dn9IXbfq4EjVaTHBfvuILU/dKRppWvjnm2lRtqCZ+LIT3ATbAjA3/dY7dWsjxQWwijA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
-        "@aws-sdk/util-endpoints": "3.306.0",
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -716,14 +749,14 @@
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.306.0.tgz",
-      "integrity": "sha512-+m+ALxNx5E1zLPPijO1pAbT5tnofLzZFWlnSYBEiOIwzaRU44rLYDqAhgXJkMMbOECkffDrv6ym0oWJIwJI+DA==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.357.0.tgz",
+      "integrity": "sha512-kwBIzKCaW3UWqLdELhy7TcN8itNMOjbzga530nalFILMvn2IxrkdKQhNgxGBXy6QK6kCOtH6OmcrG3/oZkLwig==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.306.0",
-        "@aws-sdk/shared-ini-file-loader": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -731,15 +764,15 @@
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.306.0.tgz",
-      "integrity": "sha512-qvNSIVdGf0pnWEXsAulIqXk7LML25Zc1yxbujxoAj8oX5y+mDhzQdHKrMgc0FuI4RKoEd9px4DYoUbmTWrrxwA==",
+      "version": "3.360.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.360.0.tgz",
+      "integrity": "sha512-oMsXdMmNwHpUbebETO44bq0N4SocEMGfPjYNUTRs8md7ita5fuFd2qFuvf+ZRt6iVcGWluIqmF8DidD+b7d+TA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.306.0",
-        "@aws-sdk/protocol-http": "3.306.0",
-        "@aws-sdk/querystring-builder": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/abort-controller": "3.357.0",
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/querystring-builder": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -747,12 +780,12 @@
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.306.0.tgz",
-      "integrity": "sha512-37PnbjpANjHys0Y+DVmKUz1JbSGZ/mAndZeplTUsFDUtbNwJRw/fDyWUvGC82JWB4gNSP5muWscFvetZnK2l8A==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.357.0.tgz",
+      "integrity": "sha512-im4W0u8WaYxG7J7ko4Xl3OEzK3Mrm1Rz6/txTGe6hTIHlyUISu1ekOQJXK6XYPqNMn8v1G3BiQREoRXUEJFbHg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -760,12 +793,12 @@
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.306.0.tgz",
-      "integrity": "sha512-6Z8bqB8Ydz/qG7+lJzjwsjIca2w2zp4nZ2HjxMoUm0NBbVXGDx7H9qy9eOUqEiCbdXbsfK2BmVQreLhFLt056Q==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.357.0.tgz",
+      "integrity": "sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -773,13 +806,13 @@
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.306.0.tgz",
-      "integrity": "sha512-kvz6fLwE4KojTxbphuo9JPwKKuhau2mmSurnqhtf77t9+0cOh2uzyYhIUtOFewpLj+qGoh4b2EODlJqczc7IKg==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.357.0.tgz",
+      "integrity": "sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.306.0",
-        "@aws-sdk/util-uri-escape": "3.303.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -787,12 +820,12 @@
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.306.0.tgz",
-      "integrity": "sha512-YjOdLcyS/8sNkFPgnxyUx+cM/P2XFGCA2WjQ0e9AXX8xFFkmnY6U5w2EknQ5zyvKy+R/KAV0KAMJBUB+ofjg0A==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.357.0.tgz",
+      "integrity": "sha512-Svvq+atRNP9s2VxiklcUNgCzmt3T5kfs7X2C+yjmxHvOQTPjLNaNGbfC/vhjOK7aoXw0h+lBac48r5ymx1PbQA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -800,21 +833,21 @@
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.306.0.tgz",
-      "integrity": "sha512-lmXIVHWU5J60GmmTgyj79kupWYg5ntyNrUPt1P9FYTsXz+tdk4YYH7/2IxZ1XjBr4jEsN56gfSI0cfT07ztQJA==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.357.0.tgz",
+      "integrity": "sha512-VuXeL4g5vKO9HjgCZlxmH8Uv1FcqUSjmbPpQkbNtYIDck6u0qzM0rG+n0/1EjyQbPSr3MhW/pkWs5nx2Nljlyg==",
       "optional": true,
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.306.0.tgz",
-      "integrity": "sha512-mDmBRN+Y0+EBD5megId97UIJGV/rmRsAds22qy0mmVdD3X7qlxn974btXVgfZyda6qw/pX6hgi8X99Qj6Wjb0w==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.357.0.tgz",
+      "integrity": "sha512-ceyqM4XxQe0Plb/oQAD2t1UOV2Iy4PFe1oAGM8dfJzYrRKu7zvMwru7/WaB3NYq+/mIY6RU+jjhRmjQ3GySVqA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -822,17 +855,18 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.306.0.tgz",
-      "integrity": "sha512-yoQTo6wLirKHg34Zhm8tKmfEaK8fOn+psVdMtRs2vGq3uzKLb+YW5zywnujoVwBvygQTWxiDMwRxDduWAisccA==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.357.0.tgz",
+      "integrity": "sha512-itt4/Jh9FqnzK30qIjXFBvM4J7zN4S/AAqsRMnaX7U4f/MV+1YxQHmzimpdMnsCXXs2jqFqKVRu6DewxJ3nbxg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.303.0",
-        "@aws-sdk/types": "3.306.0",
-        "@aws-sdk/util-hex-encoding": "3.295.0",
-        "@aws-sdk/util-middleware": "3.306.0",
-        "@aws-sdk/util-uri-escape": "3.303.0",
-        "@aws-sdk/util-utf8": "3.303.0",
+        "@aws-sdk/eventstream-codec": "3.357.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.357.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -840,13 +874,15 @@
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.306.0.tgz",
-      "integrity": "sha512-AFdNkto0Md6laio9t70WtvocoZqVcAydbY5csimXQh+lhKVmy/C+ZcKarDvaa0JD6PjSHb4snYzcINFpHW5LJQ==",
+      "version": "3.360.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.360.0.tgz",
+      "integrity": "sha512-R7wbT2SkgWNEAxMekOTNcPcvBszabW2+qHjrcelbbVJNjx/2yK+MbpZI4WRSncByQMeeoW+aSUP+JgsbpiOWfw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/middleware-stack": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-stream": "3.360.0",
+        "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -854,15 +890,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.306.0.tgz",
-      "integrity": "sha512-GQlUx9u+fHLjOJedudLM//j7RSZAip57n59bjn/I3TRVjDs065opNu2xSWMPm1n46kPx6VA5z+DktvuFeAblxQ==",
+      "version": "3.362.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.362.0.tgz",
+      "integrity": "sha512-w7NTeB2j1CRdvDa7m08KQr12HN6qrOknXhGEMmf67bfdfAdmPWsJXIbxcKH8eze+acOzoimbqv8KyCVmyX/pCQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.306.0",
-        "@aws-sdk/property-provider": "3.306.0",
-        "@aws-sdk/shared-ini-file-loader": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/client-sso-oidc": "3.362.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -870,9 +906,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.306.0.tgz",
-      "integrity": "sha512-RnyknWWpQcRmNH7AsNr89sdhOoltCU/4YEwBMw34Eh+/36l7HfA5PdEKbsOkO7MO4+2g5qmmm/AHcnHRvymApg==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -882,23 +918,23 @@
       }
     },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.306.0.tgz",
-      "integrity": "sha512-mhyOjtycZgxKYo2CoDhDQONuRd5TLfEwmyGWVgFrfubF0LejQ3rkBRLC5zT9TBZ8RJHNlqU2oGdsZCy3JV6Rlw==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.357.0.tgz",
+      "integrity": "sha512-fAaU6cFsaAba01lCRsRJiYR/LfXvX2wudyEyutBVglE4dWSoSeu3QJNxImIzTBULfbiFhz59++NQ1JUVx88IVg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/querystring-parser": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-base64": {
-      "version": "3.303.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.303.0.tgz",
-      "integrity": "sha512-oj+p/GHHPcZEKjiiOHU/CyNQeh8i+8dfMMzU+VGdoK5jHaVG8h2b+V7GPf7I4wDkG2ySCK5b5Jw5NUHwdTJ13Q==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.303.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -906,18 +942,18 @@
       }
     },
     "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.303.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.303.0.tgz",
-      "integrity": "sha512-T643m0pKzgjAvPFy4W8zL+aszG3T22U8hb6stlMvT0z++Smv8QfIvkIkXjWyH2KlOt5GKliHwdOv8SAi0FSMJQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.303.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.303.0.tgz",
-      "integrity": "sha512-/hS8z6e18Le60hJr2TUIFoUjUiAsnQsuDn6DxX74GXhMOHeSwZDJ9jHF39quYkNMmAE37GrVH4MI9vE0pN27qw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -927,12 +963,12 @@
       }
     },
     "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.303.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.303.0.tgz",
-      "integrity": "sha512-hUU+NW+SW6RNojtAKnnmz+tDShVKlEx2YsS4a5fSfrKRUes+zWz10cxVX0RQfysd3R6tdSHhbjsSj8eCIybheg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.303.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -940,9 +976,9 @@
       }
     },
     "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.295.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.295.0.tgz",
-      "integrity": "sha512-/5Dl1aV2yI8YQjqwmg4RTnl/E9NmNsx7HIwBZt+dTcOrM0LMUwczQBFFcLyqCj/qv5y+VsvLoAAA/OiBT7hb3w==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -952,13 +988,13 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.306.0.tgz",
-      "integrity": "sha512-XczPC/klGngMNDcNvThloyeKoPoG61ts1tZVcDbyRaOqmoMH80fn+c6Ah4A/BPzbo8wm1MIA9kqeJI0ypps6qQ==",
+      "version": "3.360.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.360.0.tgz",
+      "integrity": "sha512-/GR8VlK9xo1Q5WbVYuNaZ+XfoCFdWNb4z4mpoEgvEgBH4R0GjqiAqLftUA8Ykq1tJuDAKPYVzUNzK8DC0pt7/g==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/property-provider": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -967,16 +1003,16 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.306.0.tgz",
-      "integrity": "sha512-0hs/cS7Pu4sEO78n0Uv7ybBEFq5j23TOu3QNH+YMzF8n4yuQtaMwNM8DI2s03/pVGXYsPzO7036jREGcu+enXw==",
+      "version": "3.360.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.360.0.tgz",
+      "integrity": "sha512-gR3Ctqpyl7SgStDJ1Jlq6qQDuw/rS9AgbAXx+s3wsmm3fm8lHKkXkDPYVvNDqd6dVXRO6q8MRx00lwkGI4qrpQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.306.0",
-        "@aws-sdk/credential-provider-imds": "3.306.0",
-        "@aws-sdk/node-config-provider": "3.306.0",
-        "@aws-sdk/property-provider": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/config-resolver": "3.357.0",
+        "@aws-sdk/credential-provider-imds": "3.357.0",
+        "@aws-sdk/node-config-provider": "3.357.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -984,12 +1020,12 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.306.0.tgz",
-      "integrity": "sha512-aPTqU4VGhec8LDhKZrfA3/sBHTYRa0favKEo8aEa/vIZJTNBAFlUhvr5z7peAr8gBOtZZcElzX8PiK3jjn3ILw==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
+      "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -997,9 +1033,9 @@
       }
     },
     "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.295.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.295.0.tgz",
-      "integrity": "sha512-XJcoVo41kHzhe28PBm/rqt5mdCp8R6abwiW9ug1dA6FOoPUO8kBUxDv6xaOmA2hfRvd2ocFfBXaUCBqUowkGcQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -1009,9 +1045,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.295.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.295.0.tgz",
-      "integrity": "sha512-d/s+zhUx5Kh4l/ecMP/TBjzp1GR/g89Q4nWH6+wH5WgdHsK+LG+vmsk6mVNuP/8wsCofYG4NBqp5Ulbztbm9QA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -1021,9 +1057,9 @@
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.306.0.tgz",
-      "integrity": "sha512-14CSm1mTrfSNBGbkZu8vSjXYg7DUMfZc74IinOajcFtTswa/6SyiyhU9DK0a837qqwxSfFGpnE2thVeJIF/7FA==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.357.0.tgz",
+      "integrity": "sha512-pV1krjZs7BdahZBfsCJMatE8kcor7GFsBOWrQgQDm9T0We5b5xPpOO2vxAD0RytBpY8Ky2ELs/+qXMv7l5fWIA==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -1033,22 +1069,41 @@
       }
     },
     "node_modules/@aws-sdk/util-retry": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.306.0.tgz",
-      "integrity": "sha512-zcgTEIehQAIAm4vBNWfXZpDNbIrDM095vZmpbozQwK/pfDqMGvq7j3r9atKuEGTtoomoGoYwj3x/KEhO6JXJLg==",
+      "version": "3.362.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.362.0.tgz",
+      "integrity": "sha512-LDRGKaF2EMcFEa6AlS+ilLiDEeHWyR5FN2+RHdfGQjcqn+Zdd5H6Vc0vUF5Z4PH3hXr5LPZcDh+zM7DlG22KJg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/service-error-classification": "3.306.0",
+        "@aws-sdk/service-error-classification": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-stream": {
+      "version": "3.360.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream/-/util-stream-3.360.0.tgz",
+      "integrity": "sha512-t3naBfNesXwLis29pzSfLx2ifCn2180GiPjRaIsQP14IiVCBOeT1xaU6Dpyk7WeR/jW4cu7wGl+kbeyfNF6QmQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/fetch-http-handler": "3.357.0",
+        "@aws-sdk/node-http-handler": "3.360.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.303.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.303.0.tgz",
-      "integrity": "sha512-N3ULNuHCL3QzAlCTY+XRRkRQTYCTU8RRuzFCJX0pDpz9t2K+tLT7DbxqupWGNFGl5Xlulf1Is14J3BP/Dx91rA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -1058,24 +1113,24 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.306.0.tgz",
-      "integrity": "sha512-uZAtpvCasUdWRlB/nEjN0gf6G7810hT50VyWjpd6mQW78myV8M5fu/R03UFAZ+D8fhqqIdzR/IXDY1QUGp8bCA==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.357.0.tgz",
+      "integrity": "sha512-JHaWlNIUkPNvXkqeDOrqFzAlAgdwZK5mZw7FQnCRvf8tdSogpGZSkuyb9Z6rLD9gC40Srbc2nepO1cFpeMsDkA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/types": "3.357.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.306.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.306.0.tgz",
-      "integrity": "sha512-zLp9wIx7FZ0qFLimYW3lJ1uJM5gqxmmcQjNimUaUq/4a1caDkaiF/QeyyMFva+wIjyHRv22P5abUBjIEZrs5WA==",
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.357.0.tgz",
+      "integrity": "sha512-RdpQoaJWQvcS99TVgSbT451iGrlH4qpWUWFA9U1IRhxOSsmC1hz8ME7xc8nci9SREx/ZlfT3ai6LpoAzAtIEMA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.306.0",
-        "@aws-sdk/types": "3.306.0",
+        "@aws-sdk/node-config-provider": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1091,12 +1146,12 @@
       }
     },
     "node_modules/@aws-sdk/util-utf8": {
-      "version": "3.303.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.303.0.tgz",
-      "integrity": "sha512-tZXVuMOIONPOuOGBs/XRdzxv6jUvTM620dRFFIHZwlGiW8bo0x0LlonrzDAJZA4e9ZwmxJIj8Ji13WVRBGvZWg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.303.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2186,6 +2241,31 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
+      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -3646,19 +3726,25 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "optional": true,
       "dependencies": {
         "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fb-watchman": {
@@ -6742,9 +6828,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
       "optional": true
     },
     "node_modules/type-detect": {


### PR DESCRIPTION
Bumps [fast-xml-parser](https://github.com/NaturalIntelligence/fast-xml-parser) and [@aws-sdk/credential-providers](https://github.com/aws/aws-sdk-js-v3/tree/HEAD/packages/credential-providers). These dependencies needed to be updated together.

Updates `fast-xml-parser` from 4.1.2 to 4.2.5
- [Release notes](https://github.com/NaturalIntelligence/fast-xml-parser/releases)
- [Changelog](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/CHANGELOG.md)
- [Commits](https://github.com/NaturalIntelligence/fast-xml-parser/compare/v4.1.2...v4.2.5)

Updates `@aws-sdk/credential-providers` from 3.306.0 to 3.362.0
- [Release notes](https://github.com/aws/aws-sdk-js-v3/releases)
- [Changelog](https://github.com/aws/aws-sdk-js-v3/blob/main/packages/credential-providers/CHANGELOG.md)
- [Commits](https://github.com/aws/aws-sdk-js-v3/commits/v3.362.0/packages/credential-providers)

---
updated-dependencies:
- dependency-name: fast-xml-parser dependency-type: indirect
- dependency-name: "@aws-sdk/credential-providers" dependency-type: indirect ...